### PR TITLE
Update node runtime for IP blacklist lambda to nodejs8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Thank you for contributing and thanks to Juice's very own Director of Engineerin
 
 # Releases
 
+## v0.2.1
+
+Updates the Lambda runtime for the WAFIPLambda from nodejs6.10 to nodejs8.10 since 6.10 is reaching end of life.
+Runs as is with no need to repackage or change any code.  Seems to run at least 50% faster than the 6.10 runtime in the
+few test runs I've made.
+
 ## v0.2.0
 
 Added the example available in the CloudFormation template that automatically updates known malicious IP addresses and 

--- a/ipblock.tf
+++ b/ipblock.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "WAFIPLambda" {
   role             = "${aws_iam_role.WAFReputationUpdater.arn}"
   handler          = "index.handler"
   source_code_hash = "${base64sha256(file("${path.module}/WAFIPLambda.zip"))}"
-  runtime          = "nodejs6.10"
+  runtime          = "nodejs8.10"
   timeout          = 300
 }
 


### PR DESCRIPTION
Type: Fix

#### This PR introduces the following changes

- Updates the node runtime from 6.10 to 8.10 for the WAFIPLambda updater function as the .
- Update release notes.

## Documentation

In testing this change to the runtime it ran without need to modify the function code or repackage and so far has shown about 30-50% speedup. 

## Checklist

- [x] Add information to the release notes documentation
- [N/A] Add new feature to the usage documentation
