### PR TITLE
Added Runtime Variable

### DIFF
--- a/ipblock.tf
+++ b/ipblock.tf
@@ -1,10 +1,10 @@
 resource "aws_lambda_function" "WAFIPLambda" {
   filename         = "${path.module}/WAFIPLambda.zip"
-  function_name    = "WAFIPLambda"
+  function_name    = "WAFIPLambda-${var.env}"
   role             = "${aws_iam_role.WAFReputationUpdater.arn}"
   handler          = "index.handler"
   source_code_hash = "${base64sha256(file("${path.module}/WAFIPLambda.zip"))}"
-  runtime          = "nodejs8.10"
+  runtime          = "${var.runtime}"
   timeout          = 300
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,7 @@ variable "app" {
 variable "alb_arn" {
   description = "The ARN for the Application Load Balancer to associate the WAF ACL with."
 }
+
+variable "runtime"{
+  default = "nodejs10.x"
+}


### PR DESCRIPTION
Type:Feature

#### This PR introduces the following changes

- Aws has deprecated node8.x. Now we can pass in different versions of node through variables instead of it being a set value.

