### PR TITLE
OPS-1978 Terraform 0.12 Upgrade

### DIFF
--- a/bytematch.tf
+++ b/bytematch.tf
@@ -20,7 +20,7 @@ resource "aws_wafregional_rule" "byte-match-rule" {
   metric_name = "bytematchrule${var.env}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.byte-match-set.id}"
+    data_id = aws_wafregional_byte_match_set.byte-match-set.id
     negated = false
     type    = "ByteMatch"
   }

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "WAFReputationUpdater" {
   name               = "WAFReputationUpdater${var.env}"
-  assume_role_policy = "${data.aws_iam_policy_document.WAFReputationAssumeRolePolicy.json}"
+  assume_role_policy = data.aws_iam_policy_document.WAFReputationAssumeRolePolicy.json
 }
 
 data "aws_iam_policy_document" "WAFReputationAssumeRolePolicy" {
@@ -54,8 +54,8 @@ data "aws_iam_policy_document" "WAFLambdaPermissions" {
     ]
 
     resources = [
-      "${aws_wafregional_ipset.WAFIPSet1.arn}",
-      "${aws_wafregional_ipset.WAFIPSet2.arn}"
+      aws_wafregional_ipset.WAFIPSet1.arn,
+      aws_wafregional_ipset.WAFIPSet2.arn
     ]
   }
 
@@ -83,18 +83,18 @@ data "aws_iam_policy_document" "WAFLambdaPermissions" {
 
 resource "aws_iam_policy" "WAFPolicy" {
   name   = "WAFUpdaterPolicy${var.env}"
-  policy = "${data.aws_iam_policy_document.WAFLambdaPermissions.json}"
+  policy = data.aws_iam_policy_document.WAFLambdaPermissions.json
 }
 
 resource "aws_iam_role_policy_attachment" "WAFPolicyAttachment" {
-  policy_arn = "${aws_iam_policy.WAFPolicy.arn}"
-  role       = "${aws_iam_role.WAFReputationUpdater.name}"
+  policy_arn = aws_iam_policy.WAFPolicy.arn
+  role       = aws_iam_role.WAFReputationUpdater.name
 }
 
 resource "aws_lambda_permission" "AllowInvokeFromCloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.WAFIPLambda.function_name}"
+  function_name = aws_lambda_function.WAFIPLambda.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.InvokeWAFIPLambda.arn}"
+  source_arn    = aws_cloudwatch_event_rule.InvokeWAFIPLambda.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 # Cloudfront
 
 resource "aws_wafregional_web_acl" "app_acl" {
-  "default_action" {
+  default_action {
     type = "ALLOW"
   }
 
@@ -16,35 +16,35 @@ resource "aws_wafregional_web_acl" "app_acl" {
   # Here we attach all of the rules we've created to the ACL.  Lower priority values means they will be evaluated first.
   # Valid values for the type in the action block of the rule are: BLOCK, ALLOW, and COUNT.
   rule {
-    "action" {
-      type = "BLOCK"
+    action {
+      type = var.SQLI_ACTION
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.sql-inj-rule.id}"
-  }
-
-  rule {
-    "action" {
-      type = "BLOCK"
-    }
-
-    priority = 2
-    rule_id  = "${aws_wafregional_rule.byte-match-rule.id}"
+    rule_id  = aws_wafregional_rule.sql-inj-rule.id
   }
 
   rule {
     action {
-      type = "BLOCK"
+      type = var.BYTE_MATCH_ACTION
+    }
+
+    priority = 2
+    rule_id  = aws_wafregional_rule.byte-match-rule.id
+  }
+
+  rule {
+    action {
+      type = var.IP_ACTION
     }
     priority = 3
-    rule_id = "${aws_wafregional_rule.WAFIPRule.id}"
+    rule_id = aws_wafregional_rule.WAFIPRule.id
   }
 }
 
 # Associate our WEB ACL with the ALB
 
 resource "aws_wafregional_web_acl_association" "alb-association" {
-  resource_arn = "${var.alb_arn}"
-  web_acl_id   = "${aws_wafregional_web_acl.app_acl.id}"
+  resource_arn = var.alb_arn
+  web_acl_id   = aws_wafregional_web_acl.app_acl.id
 }

--- a/sqlinjection.tf
+++ b/sqlinjection.tf
@@ -105,7 +105,7 @@ resource "aws_wafregional_rule" "sql-inj-rule" {
   metric_name = "sqlinjrule${var.env}"
 
   predicate {
-    data_id = "${aws_wafregional_sql_injection_match_set.sqli-match-set.id}"
+    data_id = aws_wafregional_sql_injection_match_set.sqli-match-set.id
     negated = false
     type    = "SqlInjectionMatch"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,15 @@ variable "alb_arn" {
 variable "runtime"{
   default = "nodejs10.x"
 }
+
+variable "SQLI_ACTION" {
+  default = "BLOCK"
+}
+
+variable "BYTE_MATCH_ACTION" {
+  default = "BLOCK"
+}
+
+variable "IP_ACTION" {
+  default = "BLOCK"
+}


### PR DESCRIPTION
Type: Improvement

#### This PR introduces the following changes

- Upgrades to HLC2 syntax.
- Introduce new variables, with default BLOCK, that will let you selectively change the action for rules (such as to COUNT) without having to go into the module itself.